### PR TITLE
fix(bot): correct API field names and config path

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -1,13 +1,17 @@
 """Configuration loading from environment variables."""
 
+from pathlib import Path
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Get the directory containing this config file
+BOT_DIR = Path(__file__).resolve().parent
 
 
 class BotConfig(BaseSettings):
     """Bot configuration loaded from environment variables."""
 
     model_config = SettingsConfigDict(
-        env_file=".env.bot.secret",
+        env_file=BOT_DIR / ".env.bot.secret",
         env_file_encoding="utf-8",
         extra="ignore",
     )

--- a/bot/handlers/commands/command_handlers.py
+++ b/bot/handlers/commands/command_handlers.py
@@ -52,19 +52,17 @@ def handle_labs(command: str, args: str = "") -> str:
         if not items:
             return "📋 No labs available."
         
-        # Group items by lab_id
-        labs = {}
+        # Filter only labs (not tasks) and extract titles
+        labs = []
         for item in items:
-            lab_id = item.get("lab_id", "Unknown")
-            lab_name = item.get("lab_name", "Unknown Lab")
-            if lab_id not in labs:
-                labs[lab_id] = lab_name
+            if item.get("type") == "lab":
+                labs.append(item.get("title", "Unknown Lab"))
         
         if not labs:
             return "📋 No labs found."
         
         lines = ["📋 Available Labs:\n"]
-        for lab_id, lab_name in sorted(labs.items()):
+        for lab_name in labs:
             lines.append(f"- {lab_name}")
         
         return "\n".join(lines)
@@ -87,8 +85,8 @@ def handle_scores(command: str, args: str = "") -> str:
         
         lines = [f"📊 Pass rates for {args}:"]
         for rate in pass_rates:
-            task_name = rate.get("task_name", "Unknown Task")
-            pass_rate = rate.get("pass_rate", 0)
+            task_name = rate.get("task", "Unknown Task")
+            pass_rate = rate.get("avg_score", 0)
             attempts = rate.get("attempts", 0)
             lines.append(f"- {task_name}: {pass_rate:.1f}% ({attempts} attempts)")
         


### PR DESCRIPTION
- Use absolute path for .env.bot.secret in config.py
- Fix handle_labs to use 'title' field from items API
- Fix handle_scores to use 'task' and 'avg_score' fields

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #<issue-number>

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
