### PR TITLE
feat: Implement Task 3 - LLM intent routing with tool calling

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -3,7 +3,7 @@
 
 Usage:
     uv run bot.py              # Start Telegram bot
-    uv run bot.py --test "/command"  # Test mode (no Telegram connection)
+    uv run bot.py --test "message"  # Test mode (no Telegram connection)
 """
 
 import argparse
@@ -12,6 +12,7 @@ from typing import Callable
 
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import CommandStart, Command
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 from config import config
 from handlers import (
@@ -21,11 +22,12 @@ from handlers import (
     handle_labs,
     handle_scores,
 )
+from services.llm_client import LLMClient
 
 
 def parse_command(text: str) -> tuple[str, str]:
     """Parse a command string into command and args.
-    
+
     Example: "/scores lab-01" -> ("/scores", "lab-01")
     """
     parts = text.strip().split(maxsplit=1)
@@ -46,25 +48,56 @@ def get_handler(command: str) -> Callable[[str, str], str]:
     return handlers.get(command)
 
 
-async def run_test_mode(command_text: str) -> None:
-    """Run in test mode — call handler directly and print result."""
-    command, args = parse_command(command_text)
-    handler = get_handler(command)
+async def run_test_mode(message_text: str) -> None:
+    """Run in test mode — use LLM intent routing for plain text."""
+    # Check if it's a slash command
+    if message_text.startswith("/"):
+        command, args = parse_command(message_text)
+        handler = get_handler(command)
 
-    if handler is None:
-        print(f"Unknown command: {command}")
-        print("Available commands: /start, /help, /health, /labs, /scores")
-        sys.exit(0)
+        if handler is None:
+            print(f"Unknown command: {command}")
+            print("Available commands: /start, /help, /health, /labs, /scores")
+            sys.exit(0)
 
-    response = await handler(command, args)
-    print(response)
+        response = await handler(command, args)
+        print(response)
+    else:
+        # Plain text — use LLM intent routing
+        if not config.llm_api_key or not config.llm_api_base_url:
+            print("Error: LLM_API_KEY or LLM_API_BASE_URL not set in .env.bot.secret")
+            sys.exit(1)
+
+        llm = LLMClient(config.llm_api_base_url, config.llm_api_key, config.llm_api_model)
+        response = llm.chat(message_text, debug=True)
+        print(response)
+
     sys.exit(0)
 
 
 async def handle_telegram_start(message: types.Message, bot: Bot) -> None:
     """Telegram handler for /start."""
     response = await handle_start("/start", "")
-    await message.answer(response)
+
+    # Add inline keyboard buttons for common actions
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="🏥 Health", callback_data="health"),
+                InlineKeyboardButton(text="📚 Labs", callback_data="labs"),
+            ],
+            [
+                InlineKeyboardButton(text="📊 Scores", callback_data="scores"),
+                InlineKeyboardButton(text="❓ Help", callback_data="help"),
+            ],
+            [
+                InlineKeyboardButton(text="🏆 Top Learners", callback_data="top_learners"),
+                InlineKeyboardButton(text="📈 Pass Rates", callback_data="pass_rates"),
+            ],
+        ]
+    )
+
+    await message.answer(response, reply_markup=keyboard)
 
 
 async def handle_telegram_help(message: types.Message, bot: Bot) -> None:
@@ -92,11 +125,36 @@ async def handle_telegram_scores(message: types.Message, bot: Bot) -> None:
     await message.answer(response)
 
 
+async def handle_telegram_callback(message: types.CallbackQuery, bot: Bot) -> None:
+    """Handle inline keyboard button callbacks."""
+    action = message.data
+
+    if action == "health":
+        response = await handle_health("/health", "")
+    elif action == "labs":
+        response = await handle_labs("/labs", "")
+    elif action == "help":
+        response = await handle_help("/help", "")
+    elif action == "scores":
+        response = "Please use /scores <lab-name> to view scores, e.g., /scores lab-01"
+    elif action == "top_learners":
+        response = "Please ask: 'who are the top 5 students in lab-01?'"
+    elif action == "pass_rates":
+        response = "Please ask: 'what are the pass rates for lab-01?'"
+    else:
+        response = "Unknown action."
+
+    await message.answer(response)
+
+
 async def handle_telegram_message(message: types.Message, bot: Bot) -> None:
-    """Handle plain text messages (Task 3: intent routing)."""
-    # Task 3: Add LLM-based intent routing here
-    response = "I understand you're asking about: " + message.text
-    response += "\n\n(Task 3: I'll learn to route this to the right handler)"
+    """Handle plain text messages with LLM-based intent routing."""
+    if not config.llm_api_key or not config.llm_api_base_url:
+        await message.answer("LLM configuration is missing. Please contact the administrator.")
+        return
+
+    llm = LLMClient(config.llm_api_base_url, config.llm_api_key, config.llm_api_model)
+    response = llm.chat(message.text, debug=False)
     await message.answer(response)
 
 
@@ -106,10 +164,10 @@ async def run_telegram_bot() -> None:
         print("Error: BOT_TOKEN not set in .env.bot.secret")
         print("Copy .env.bot.example to .env.bot.secret and fill in your bot token")
         sys.exit(1)
-    
+
     bot = Bot(token=config.bot_token)
     dp = Dispatcher()
-    
+
     # Register handlers
     dp.message.register(handle_telegram_start, CommandStart())
     dp.message.register(handle_telegram_help, Command("help"))
@@ -117,7 +175,8 @@ async def run_telegram_bot() -> None:
     dp.message.register(handle_telegram_labs, Command("labs"))
     dp.message.register(handle_telegram_scores, Command("scores"))
     dp.message.register(handle_telegram_message)  # Plain text messages
-    
+    dp.callback_query.register(handle_telegram_callback)  # Inline keyboard callbacks
+
     print("Bot is starting...")
     await dp.start_polling(bot)
 
@@ -127,8 +186,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="LMS Telegram Bot")
     parser.add_argument(
         "--test",
-        metavar="COMMAND",
-        help="Test mode: run a command and print result (e.g., --test '/start')",
+        metavar="MESSAGE",
+        help="Test mode: send a message and print result (e.g., --test 'what labs are available')",
     )
 
     args = parser.parse_args()

--- a/bot/services/llm_client.py
+++ b/bot/services/llm_client.py
@@ -1,0 +1,327 @@
+"""LLM client with tool calling support for intent routing."""
+
+import json
+import sys
+from typing import Any
+
+import httpx
+
+from config import config
+
+
+class LLMClient:
+    """HTTP client for the LLM API with tool calling support."""
+
+    def __init__(self, base_url: str, api_key: str, model: str) -> None:
+        """Initialize the LLM client.
+
+        Args:
+            base_url: Base URL of the LLM API (e.g., http://localhost:42005/v1)
+            api_key: API key for authentication
+            model: Model name to use
+        """
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=60.0,
+        )
+
+    def get_tools(self) -> list[dict[str, Any]]:
+        """Return the list of tool definitions for the LLM.
+
+        These tools map to the 9 backend endpoints.
+        """
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_items",
+                    "description": "Get a list of all labs and tasks available in the system",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_learners",
+                    "description": "Get a list of enrolled learners and their groups",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_scores",
+                    "description": "Get score distribution (4 buckets) for a specific lab",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            },
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_pass_rates",
+                    "description": "Get per-task average scores and attempt counts for a lab",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            },
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_timeline",
+                    "description": "Get submission timeline (submissions per day) for a lab",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            },
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_groups",
+                    "description": "Get per-group scores and student counts for a lab",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            },
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_top_learners",
+                    "description": "Get top N learners by score for a lab",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "description": "Number of top learners to return, e.g., 5, 10",
+                            },
+                        },
+                        "required": ["lab", "limit"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_completion_rate",
+                    "description": "Get completion rate percentage for a lab",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "lab": {
+                                "type": "string",
+                                "description": "Lab identifier, e.g., 'lab-01', 'lab-04'",
+                            },
+                        },
+                        "required": ["lab"],
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "trigger_sync",
+                    "description": "Trigger a data sync from the autochecker to refresh data",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            },
+        ]
+
+    def _execute_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        """Execute a tool call by making the appropriate API request.
+
+        Args:
+            name: Tool/function name
+            arguments: Arguments passed by the LLM
+
+        Returns:
+            Tool result (API response data)
+        """
+        from services.lms_client import LMSClient
+
+        lms = LMSClient(config.lms_api_base_url, config.lms_api_key)
+
+        if name == "get_items":
+            return lms.get_items()
+        elif name == "get_learners":
+            return lms.get_learners()
+        elif name == "get_scores":
+            return lms.get_scores(arguments.get("lab", ""))
+        elif name == "get_pass_rates":
+            return lms.get_pass_rates(arguments.get("lab", ""))
+        elif name == "get_timeline":
+            return lms.get_timeline(arguments.get("lab", ""))
+        elif name == "get_groups":
+            return lms.get_groups(arguments.get("lab", ""))
+        elif name == "get_top_learners":
+            return lms.get_top_learners(arguments.get("lab", ""), arguments.get("limit", 5))
+        elif name == "get_completion_rate":
+            return lms.get_completion_rate(arguments.get("lab", ""))
+        elif name == "trigger_sync":
+            return lms.trigger_sync()
+        else:
+            return {"error": f"Unknown tool: {name}"}
+
+    def chat(self, user_message: str, debug: bool = False) -> str:
+        """Chat with the LLM using tool calling for intent routing.
+
+        Args:
+            user_message: The user's message
+            debug: If True, print debug output to stderr
+
+        Returns:
+            The LLM's response text
+        """
+        tools = self.get_tools()
+
+        system_prompt = """You are a helpful assistant for a Learning Management System (LMS) Telegram bot.
+You have access to tools that fetch data from the backend API.
+
+When a user asks a question:
+1. Think about what information you need to answer
+2. Call the appropriate tool(s) to get that data
+3. Use the tool results to formulate a helpful, accurate response
+4. If the user's message is gibberish or unclear, provide a helpful response explaining what you can do
+5. If the user greets you, respond warmly and mention you can help with labs, scores, and analytics
+
+Available tools:
+- get_items: List all labs and tasks
+- get_learners: List enrolled students and groups
+- get_scores: Score distribution for a lab (requires lab parameter)
+- get_pass_rates: Pass rates per task for a lab (requires lab parameter)
+- get_timeline: Submission timeline for a lab (requires lab parameter)
+- get_groups: Per-group scores for a lab (requires lab parameter)
+- get_top_learners: Top N learners for a lab (requires lab and limit parameters)
+- get_completion_rate: Completion rate for a lab (requires lab parameter)
+- trigger_sync: Refresh data from autochecker
+
+Always call tools when you need data. Don't make up numbers — use the tool results.
+"""
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+
+        max_iterations = 10
+        iteration = 0
+
+        while iteration < max_iterations:
+            iteration += 1
+
+            response = self._client.post(
+                "/chat/completions",
+                json={
+                    "model": self.model,
+                    "messages": messages,
+                    "tools": tools,
+                    "tool_choice": "auto",
+                },
+            )
+
+            if response.status_code != 200:
+                if debug:
+                    print(f"[LLM] HTTP {response.status_code}: {response.text}", file=sys.stderr)
+                return f"LLM error: HTTP {response.status_code}"
+
+            data = response.json()
+            choice = data["choices"][0]["message"]
+
+            # Check if LLM wants to call tools
+            tool_calls = choice.get("tool_calls")
+
+            if not tool_calls:
+                # LLM returned final answer
+                return choice.get("content", "I don't have a response for that.")
+
+            # Execute tool calls
+            for tool_call in tool_calls:
+                function_name = tool_call["function"]["name"]
+                function_args = json.loads(tool_call["function"]["arguments"])
+
+                if debug:
+                    print(f"[tool] LLM called: {function_name}({function_args})", file=sys.stderr)
+
+                result = self._execute_tool(function_name, function_args)
+
+                if debug:
+                    result_preview = str(result)[:100]
+                    if len(str(result)) > 100:
+                        result_preview += "..."
+                    print(f"[tool] Result: {result_preview}", file=sys.stderr)
+
+                # Feed tool result back to LLM
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [tool_call],
+                    }
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call["id"],
+                        "content": json.dumps(result, default=str),
+                    }
+                )
+
+            if debug:
+                print(f"[summary] Feeding {len(tool_calls)} tool result(s) back to LLM", file=sys.stderr)
+
+        return "I'm having trouble processing your request. Please try rephrasing."

--- a/bot/services/lms_client.py
+++ b/bot/services/lms_client.py
@@ -6,13 +6,13 @@ from typing import Any
 
 class LMSClient:
     """HTTP client for the LMS backend API.
-    
+
     Uses Bearer token authentication and handles errors gracefully.
     """
-    
+
     def __init__(self, base_url: str, api_key: str) -> None:
         """Initialize the LMS client.
-        
+
         Args:
             base_url: Base URL of the LMS backend (e.g., http://localhost:42002)
             api_key: API key for authentication
@@ -24,18 +24,18 @@ class LMSClient:
             headers={"Authorization": f"Bearer {self.api_key}"},
             timeout=10.0,
         )
-    
+
     def _request(self, method: str, path: str, params: dict[str, Any] | None = None) -> dict[str, Any] | list[Any]:
         """Make an authenticated request to the backend.
-        
+
         Args:
             method: HTTP method (GET, POST, etc.)
             path: API path (e.g., "/items/", "/analytics/pass-rates")
             params: Optional query parameters
-            
+
         Returns:
             JSON response as dict or list
-            
+
         Raises:
             ConnectionError: If backend is unreachable
             httpx.HTTPStatusError: If backend returns an error status
@@ -54,42 +54,103 @@ class LMSClient:
             ) from e
         except httpx.TimeoutException:
             raise ConnectionError(f"timeout connecting to backend ({self.base_url}). The service is taking too long to respond.")
-    
+
     def get_items(self) -> list[dict[str, Any]]:
         """Fetch all items (labs and tasks) from the backend.
-        
+
         Returns:
             List of items with their metadata
         """
         return self._request("GET", "/items/")
-    
+
     def get_pass_rates(self, lab: str) -> list[dict[str, Any]]:
         """Fetch pass rates for a specific lab.
-        
+
         Args:
             lab: Lab identifier (e.g., "lab-01", "lab-04")
-            
+
         Returns:
             List of pass rate data per task
         """
         return self._request("GET", "/analytics/pass-rates", params={"lab": lab})
-    
+
     def get_scores(self, lab: str) -> list[dict[str, Any]]:
         """Fetch score distribution for a specific lab.
-        
+
         Args:
             lab: Lab identifier
-            
+
         Returns:
             List of score bucket data
         """
         return self._request("GET", "/analytics/scores", params={"lab": lab})
-    
+
     def health_check(self) -> dict[str, Any]:
         """Check if the backend is healthy.
-        
+
         Returns:
             Health status with item count
         """
         items = self.get_items()
         return {"healthy": True, "item_count": len(items)}
+
+    def get_learners(self) -> list[dict[str, Any]]:
+        """Fetch all enrolled learners and their groups.
+
+        Returns:
+            List of learners with their metadata
+        """
+        return self._request("GET", "/learners/")
+
+    def get_timeline(self, lab: str) -> list[dict[str, Any]]:
+        """Fetch submission timeline for a specific lab.
+
+        Args:
+            lab: Lab identifier
+
+        Returns:
+            List of timeline data (submissions per day)
+        """
+        return self._request("GET", "/analytics/timeline", params={"lab": lab})
+
+    def get_groups(self, lab: str) -> list[dict[str, Any]]:
+        """Fetch per-group scores and student counts for a lab.
+
+        Args:
+            lab: Lab identifier
+
+        Returns:
+            List of group data
+        """
+        return self._request("GET", "/analytics/groups", params={"lab": lab})
+
+    def get_top_learners(self, lab: str, limit: int = 5) -> list[dict[str, Any]]:
+        """Fetch top N learners by score for a lab.
+
+        Args:
+            lab: Lab identifier
+            limit: Number of top learners to return
+
+        Returns:
+            List of top learners with their scores
+        """
+        return self._request("GET", "/analytics/top-learners", params={"lab": lab, "limit": limit})
+
+    def get_completion_rate(self, lab: str) -> dict[str, Any]:
+        """Fetch completion rate percentage for a lab.
+
+        Args:
+            lab: Lab identifier
+
+        Returns:
+            Completion rate data
+        """
+        return self._request("GET", "/analytics/completion-rate", params={"lab": lab})
+
+    def trigger_sync(self) -> dict[str, Any]:
+        """Trigger a data sync from the autochecker.
+
+        Returns:
+            Sync status
+        """
+        return self._request("POST", "/pipeline/sync")


### PR DESCRIPTION
- Add LLMClient service with 9 tool definitions for backend endpoints
- Implement tool calling loop: LLM decides → execute tools → feed results back
- Add inline keyboard buttons for common actions (Health, Labs, Scores, etc.)
- Update bot.py to use LLM routing for plain text messages
- Add all missing endpoint methods to LMSClient (get_learners, get_groups, etc.)
- Support multi-step reasoning (e.g., 'which lab has lowest pass rate')
- Add fallback handling for gibberish and greetings
- Debug logging to stderr for --test mode

<!-- Provide a general summary of your changes in the Title above -->

## Summary

<!-- What does this PR do?

Replace <issue-number> with the number of the corresponding task issue.

Add more details if necessary.
-->

- Closes #14 

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [ ] I see `base: main` <- `compare: <branch>` above the PR title.
- [ ] I edited the line `- Closes #<issue-number>`.
- [ ] I wrote clear commit messages.
- [ ] I reviewed my own diff before requesting review.
- [ ] I understand the changes I’m submitting.
